### PR TITLE
euiAnimator header

### DIFF
--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -14,7 +14,7 @@ namespace ui2d {
 namespace eui {
 class LayoutEx;
 
-class Animator : public AnimTransformBasic {
+class Animator : public nn::ui2d::AnimTransformBasic {
 public:
     NN_RUNTIME_TYPEINFO(AnimTransformBasic);
 

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -2,13 +2,11 @@
 
 #include <nn/font/font_Util.h>
 #include <nn/ui2d/ui2d_Animation.h>
-#include <nn/ui2d/ui2d_Pane.h>
 
 namespace nn {
 namespace ui2d {
 class Group;
-class AnimTransformBasic;
-class AnimResource;
+class Pane;
 } // namespace ui2d
 } // namespace nn
 

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <nn/font/font_Util.h>
+#include <nn/ui2d/ui2d_Animation.h>
 #include <nn/ui2d/ui2d_Pane.h>
 
 namespace nn {
 namespace ui2d {
-    class Group;
-    class AnimTransformBasic;
-    class AnimResource;
-}
-}
+class Group;
+class AnimTransformBasic;
+class AnimResource;
+} // namespace ui2d
+} // namespace nn
 
 namespace eui {
 class LayoutEx;
@@ -18,11 +19,7 @@ class Animator : public nn::ui2d::AnimTransformBasic {
 public:
     NN_RUNTIME_TYPEINFO(AnimTransformBasic);
 
-    enum PlayType {
-        PLAYTYPE_ONESHOT,
-        PLAYTYPE_LOOP,
-        PLAYTYPE_ROUNDTRIP
-    };
+    enum PlayType { PLAYTYPE_ONESHOT, PLAYTYPE_LOOP, PLAYTYPE_ROUNDTRIP };
 
     Animator();
     virtual ~Animator();
@@ -33,17 +30,17 @@ public:
     virtual void PlayRandom(PlayType type, f32 speed);
     virtual void SetEnabled(bool bEnabled);
 
-    virtual void SetupBasic(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, bool enabled);
-    virtual void SetupWithGroup(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::Group *pGroup, bool enabled);
-    virtual void SetupWithGroupAll(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::GroupContainer *pGroupCont, bool enabled);
-    virtual void SetupWithGroupIndex(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::GroupContainer *pGroupCont, u32 idx, bool enabled);
-    virtual void SetupWithPane(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::Pane *pPane, bool enabled);
+    virtual void SetupBasic(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, bool enabled);
+    virtual void SetupWithGroup(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::Group* pGroup, bool enabled);
+    virtual void SetupWithGroupAll(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::GroupContainer* pGroupCont, bool enabled);
+    virtual void SetupWithGroupIndex(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::GroupContainer* pGroupCont, u32 idx, bool enabled);
+    virtual void SetupWithPane(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::Pane* pPane, bool enabled);
 
     virtual void Stop(f32 frame);
     virtual void StopAtMin();
     virtual void StopAtMax();
     virtual void StopCurrent();
-    virtual void Synchronize(const eui::Animator &animator);
+    virtual void Synchronize(const Animator& animator);
     virtual void UpdateFrame(f32 progress_frame);
 }
-}
+} // namespace eui

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -17,7 +17,7 @@ class Animator : public nn::ui2d::AnimTransformBasic {
 public:
     NN_RUNTIME_TYPEINFO(AnimTransformBasic);
 
-    enum PlayType { PLAYTYPE_ONESHOT, PLAYTYPE_LOOP, PLAYTYPE_ROUNDTRIP };
+    enum class PlayType { PLAYTYPE_ONESHOT, PLAYTYPE_LOOP, PLAYTYPE_ROUNDTRIP };
 
     Animator();
     virtual ~Animator();

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <nn/font/font_Util.h>
+
+#include <nn/ui2d/ui2d_Animation.h>
+#include <nn/ui2d/ui2d_Group.h>
+#include <nn/ui2d/ui2d_Pane.h>
+
+#include <eui/lytex/euiLayoutEx.h>
+
+namespace eui {
+
+class Animator : public AnimTransformBasic {
+public:
+    NN_RUNTIME_TYPEINFO_BASE();
+
+    enum PlayType {
+        PLAYTYPE_ONESHOT,
+        PLAYTYPE_LOOP,
+        PLAYTYPE_ROUNDTRIP
+    };
+
+    Animator();
+    virtual ~Animator();
+
+    virtual void Play(PlayType type, f32 speed);
+    virtual void PlayAuto(f32 speed);
+    virtual void PlayFromCurrent(PlayType type, f32 speed);
+    virtual void PlayRandom(PlayType type, f32 speed);
+    virtual void SetEnabled(bool bEnabled);
+
+    virtual void SetupBasic(const AnimResource &animRes, LayoutEx *pLayoutEx, bool enabled);
+    virtual void SetupWithGroup(const AnimResource &animRes, LayoutEx *pLayoutEx, Group *pGroup, bool enabled);
+    virtual void SetupWithGroupAll(const AnimResource &animRes, LayoutEx *pLayoutEx, GroupContainer *pGroupCont, bool enabled);
+    virtual void SetupWithGroupIndex(const AnimResource &animRes, LayoutEx *pLayoutEx, GroupContainer *pGroupCont, u32 idx, bool enabled);
+    virtual void SetupWithPane(const AnimResource &animRes, LayoutEx *pLayoutEx, Pane *pPane, bool enabled);
+
+    virtual void Stop(f32 frame);
+    virtual void StopAtMin();
+    virtual void StopAtMax();
+    virtual void StopCurrent();
+    virtual void Synchronize(const Animator &animator);
+    virtual void UpdateFrame(f32 progress_frame);
+}
+}

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -45,5 +45,5 @@ public:
     virtual void StopCurrent();
     virtual void Synchronize(const Animator& animator);
     virtual void UpdateFrame(f32 progress_frame);
-}
+};
 }  // namespace eui

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -1,18 +1,22 @@
 #pragma once
 
 #include <nn/font/font_Util.h>
-
-#include <nn/ui2d/ui2d_Animation.h>
-#include <nn/ui2d/ui2d_Group.h>
 #include <nn/ui2d/ui2d_Pane.h>
 
-#include <eui/lytex/euiLayoutEx.h>
+namespace nn {
+namespace ui2d {
+    class Group;
+    class AnimTransformBasic;
+    class AnimResource;
+}
+}
 
 namespace eui {
+class LayoutEx;
 
 class Animator : public AnimTransformBasic {
 public:
-    NN_RUNTIME_TYPEINFO_BASE();
+    NN_RUNTIME_TYPEINFO(AnimTransformBasic);
 
     enum PlayType {
         PLAYTYPE_ONESHOT,
@@ -29,17 +33,17 @@ public:
     virtual void PlayRandom(PlayType type, f32 speed);
     virtual void SetEnabled(bool bEnabled);
 
-    virtual void SetupBasic(const AnimResource &animRes, LayoutEx *pLayoutEx, bool enabled);
-    virtual void SetupWithGroup(const AnimResource &animRes, LayoutEx *pLayoutEx, Group *pGroup, bool enabled);
-    virtual void SetupWithGroupAll(const AnimResource &animRes, LayoutEx *pLayoutEx, GroupContainer *pGroupCont, bool enabled);
-    virtual void SetupWithGroupIndex(const AnimResource &animRes, LayoutEx *pLayoutEx, GroupContainer *pGroupCont, u32 idx, bool enabled);
-    virtual void SetupWithPane(const AnimResource &animRes, LayoutEx *pLayoutEx, Pane *pPane, bool enabled);
+    virtual void SetupBasic(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, bool enabled);
+    virtual void SetupWithGroup(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::Group *pGroup, bool enabled);
+    virtual void SetupWithGroupAll(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::GroupContainer *pGroupCont, bool enabled);
+    virtual void SetupWithGroupIndex(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::GroupContainer *pGroupCont, u32 idx, bool enabled);
+    virtual void SetupWithPane(const nn::ui2d::AnimResource &animRes, eui::LayoutEx *pLayoutEx, nn::ui2d::Pane *pPane, bool enabled);
 
     virtual void Stop(f32 frame);
     virtual void StopAtMin();
     virtual void StopAtMax();
     virtual void StopCurrent();
-    virtual void Synchronize(const Animator &animator);
+    virtual void Synchronize(const eui::Animator &animator);
     virtual void UpdateFrame(f32 progress_frame);
 }
 }

--- a/include/sys/euiAnimator.h
+++ b/include/sys/euiAnimator.h
@@ -7,8 +7,8 @@ namespace nn {
 namespace ui2d {
 class Group;
 class Pane;
-} // namespace ui2d
-} // namespace nn
+}  // namespace ui2d
+}  // namespace nn
 
 namespace eui {
 class LayoutEx;
@@ -28,11 +28,16 @@ public:
     virtual void PlayRandom(PlayType type, f32 speed);
     virtual void SetEnabled(bool bEnabled);
 
-    virtual void SetupBasic(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, bool enabled);
-    virtual void SetupWithGroup(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::Group* pGroup, bool enabled);
-    virtual void SetupWithGroupAll(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::GroupContainer* pGroupCont, bool enabled);
-    virtual void SetupWithGroupIndex(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::GroupContainer* pGroupCont, u32 idx, bool enabled);
-    virtual void SetupWithPane(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx, nn::ui2d::Pane* pPane, bool enabled);
+    virtual void SetupBasic(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx,
+                            bool enabled);
+    virtual void SetupWithGroup(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx,
+                                nn::ui2d::Group* pGroup, bool enabled);
+    virtual void SetupWithGroupAll(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx,
+                                   nn::ui2d::GroupContainer* pGroupCont, bool enabled);
+    virtual void SetupWithGroupIndex(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx,
+                                     nn::ui2d::GroupContainer* pGroupCont, u32 idx, bool enabled);
+    virtual void SetupWithPane(const nn::ui2d::AnimResource& animRes, LayoutEx* pLayoutEx,
+                               nn::ui2d::Pane* pPane, bool enabled);
 
     virtual void Stop(f32 frame);
     virtual void StopAtMin();
@@ -41,4 +46,4 @@ public:
     virtual void Synchronize(const Animator& animator);
     virtual void UpdateFrame(f32 progress_frame);
 }
-} // namespace eui
+}  // namespace eui


### PR DESCRIPTION
This adds in eui's Animator, a core part of the eui system that derives from AnimTransform on ui2d.

It should be noted that the eui version of Animator utilizes things that the ui2d version doesn't, such as sead's Random classes or LayoutEx (which is not yet implemented in this repository, but probably will be soon).

Information about the PlayType enum was pulled from MK8DX, as well as things like file paths.